### PR TITLE
fixes none error when running in sp mode

### DIFF
--- a/src/Tools/open_review_dataset.py
+++ b/src/Tools/open_review_dataset.py
@@ -469,13 +469,15 @@ def pdf_to_binary_blob(arguments: Tuple):
     if skip_first_page:
         # Skip the first page, but add a page to the end
         images = pdf_to_images(name=name, pdf=pdf, num_pages=num_pages + 1)
-        images = images[1:]
     else:
         images = pdf_to_images(name=name, pdf=pdf, num_pages=num_pages)
 
     # If we were unable to extract images
     if images is None:
         return
+    
+    if skip_first_page:
+        images = images[1:]
 
     # For all images we will drop some pixels at the top because for some conferences
     # it says in the top if they were accepted or not


### PR DESCRIPTION
Dataset generation crashes when running in --skip-first-page mode, this fixes that.